### PR TITLE
Fix middleware chain execution

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,8 @@
 Style/Documentation:
   Exclude:
     - 'example/**/*'
+
+# Rubocop does not support TargetRubyVersion 2.3, while required_ruby_version
+# in the gemspec is set to 2.3.0. This will prevent related offense.
+Gemspec/RequiredRubyVersion:
+  Enabled: false

--- a/lib/yabeda/http_requests.rb
+++ b/lib/yabeda/http_requests.rb
@@ -10,14 +10,14 @@ module Yabeda
   module HttpRequests
     SNIFFER_STORAGE_SIZE = 0
 
+    LONG_RUNNING_REQUEST_BUCKETS = [
+      0.5, 1, 2.5, 5, 10, 25, 50, 100, 250, 500, 1000, # standard
+      30_000, 60_000, 120_000, 300_000, 600_000 # slow queries
+    ].freeze
+
     # rubocop: disable Metrics/BlockLength
     Yabeda.configure do
       group :http
-
-      LONG_RUNNING_REQUEST_BUCKETS = [
-        0.5, 1, 2.5, 5, 10, 25, 50, 100, 250, 500, 1000, # standard
-        30_000, 60_000, 120_000, 300_000, 600_000 # slow queries
-      ].freeze
 
       counter :request_total,
               comment: 'A counter of the total number of external HTTP \

--- a/lib/yabeda/http_requests.rb
+++ b/lib/yabeda/http_requests.rb
@@ -15,7 +15,6 @@ module Yabeda
       30_000, 60_000, 120_000, 300_000, 600_000 # slow queries
     ].freeze
 
-    # rubocop: disable Metrics/BlockLength
     Yabeda.configure do
       group :http
 
@@ -43,6 +42,5 @@ module Yabeda
         end
       end
     end
-    # rubocop: enable Metrics/BlockLength
   end
 end

--- a/lib/yabeda/http_requests/sniffer.rb
+++ b/lib/yabeda/http_requests/sniffer.rb
@@ -5,6 +5,7 @@ module Yabeda
     # Middleware for sniffer gem
     class Sniffer
       def request(data_item)
+        yield
         Yabeda.http_request_total.increment(
           host: data_item.request.host,
           port: data_item.request.port,
@@ -13,6 +14,7 @@ module Yabeda
       end
 
       def response(data_item)
+        yield
         log_http_response_total(data_item)
         log_http_response_duration(data_item)
       end

--- a/spec/http_requests/sniffer_spec.rb
+++ b/spec/http_requests/sniffer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Yabeda::HttpRequests::Sniffer do

--- a/spec/http_requests/sniffer_spec.rb
+++ b/spec/http_requests/sniffer_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+RSpec.describe Yabeda::HttpRequests::Sniffer do
+  subject(:middleware) { described_class.new }
+
+  let(:data_item) { double }
+  let(:next_middleware) { double }
+
+  before do
+    allow(data_item).to receive_message_chain(:request, :host) { 'HOST' }
+    allow(data_item).to receive_message_chain(:request, :method) { 'METHOD' }
+    allow(data_item).to receive_message_chain(:request, :port) { 'PORT' }
+    allow(data_item).to receive_message_chain(:response, :timing) { 'TIMING' }
+    allow(data_item).to receive_message_chain(:response, :status) { 'STATUS' }
+
+    allow(Yabeda).to receive_message_chain(:http_request_total, :increment) {}
+    allow(Yabeda).to receive_message_chain(:http_response_total, :increment) {}
+    allow(Yabeda).to receive_message_chain(:http_response_duration, :measure) {}
+  end
+
+  it 'chain middleware' do
+    expect(next_middleware).to receive(:call)
+    middleware.request(data_item) { next_middleware.call }
+  end
+end


### PR DESCRIPTION
The lacking `yield` caused middleware chain execution to break after `Yabeda::HttpRequests`. This patch executes next Sniffer middleware if there is one.

See https://github.com/aderyabin/sniffer/blob/d52f2631c1622fe22aa960a757bdae400fdd74b1/lib/sniffer/middleware/chain.rb#L60-L70

I had to fix some non-related Rubocop offenses to make the build pass.