### PR TITLE
Make Sniffer work with Ruby 3.0 separation of kw args

### DIFF
--- a/lib/yabeda/http_requests/sniffer.rb
+++ b/lib/yabeda/http_requests/sniffer.rb
@@ -7,9 +7,11 @@ module Yabeda
       def request(data_item)
         yield
         Yabeda.http_request_total.increment(
-          host: data_item.request.host,
-          port: data_item.request.port,
-          method: data_item.request.method
+          {
+            host: data_item.request.host,
+            port: data_item.request.port,
+            method: data_item.request.method
+          }
         )
       end
 
@@ -23,10 +25,12 @@ module Yabeda
 
       def log_http_response_total(data_item)
         Yabeda.http_response_total.increment(
-          host: data_item.request.host,
-          port: data_item.request.port,
-          method: data_item.request.method,
-          status: data_item.response.status
+          {
+            host: data_item.request.host,
+            port: data_item.request.port,
+            method: data_item.request.method,
+            status: data_item.response.status
+          }
         )
       end
 


### PR DESCRIPTION
With the release of ruby 3.0 (https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/)
keyword and positional arguments are separated (https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)

In this case we need to explicitly pass a hash to the increment
methods.