### PR TITLE
Ensure http method is always lowercase

### DIFF
--- a/lib/yabeda/http_requests/sniffer.rb
+++ b/lib/yabeda/http_requests/sniffer.rb
@@ -10,7 +10,7 @@ module Yabeda
           {
             host: data_item.request.host,
             port: data_item.request.port,
-            method: data_item.request.method
+            method: data_item.request.method.downcase
           }
         )
       end
@@ -28,7 +28,7 @@ module Yabeda
           {
             host: data_item.request.host,
             port: data_item.request.port,
-            method: data_item.request.method,
+            method: data_item.request.method.downcase,
             status: data_item.response.status
           }
         )
@@ -38,7 +38,7 @@ module Yabeda
         labels = {
           host: data_item.request.host,
           port: data_item.request.port,
-          method: data_item.request.method,
+          method: data_item.request.method.downcase,
           status: data_item.response.status
         }
 

--- a/spec/yabeda/http_requests_spec.rb
+++ b/spec/yabeda/http_requests_spec.rb
@@ -13,16 +13,16 @@ RSpec.describe Yabeda::HttpRequests do
 
     it 'holds the proper data' do
       expect(Yabeda.http_request_total.values).to(
-        eq({ host: 'sushi.com', method: 'GET', port: 80 } => 1)
+        eq({ host: 'sushi.com', method: 'get', port: 80 } => 1)
       )
       expect(Yabeda.http_response_total.values.keys.first).to(
         include({
-                  host: 'sushi.com', method: 'GET', port: 80,
+                  host: 'sushi.com', method: 'get', port: 80,
                   status: 301
                 })
       )
       expect(Yabeda.http_response_duration.values.keys.first).to(
-        eq(host: 'sushi.com', port: 80, method: 'GET', status: 301)
+        eq(host: 'sushi.com', port: 80, method: 'get', status: 301)
       )
     end
   end


### PR DESCRIPTION
Hello! I've noticed that most of my http metrics have `method` lowercase (like yabeda-rails' metrics), but sometimes I have metrics where `method` is uppercase. I assume this is a difference per http library.

Here I'm suggesting a trivial change that would ensure it's always lowercase, to match yabeda-rails. Is there appetite for this kind of normalization?

This is a backwards incompatible change with regards to the metrics themselves. I can work to make the behaviour configurable if you want, although I think this would over-complicate things.