### PR TITLE
fix rack/handler (LoadError) in example

### DIFF
--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby
+FROM ruby:3.2.1
 
 WORKDIR /app
 ADD Gemfile* ./

--- a/example/Gemfile
+++ b/example/Gemfile
@@ -7,7 +7,8 @@ gem 'yabeda-http_requests'
 gem 'yabeda-prometheus'
 
 gem 'puma'
-gem 'rack'
+gem 'rack', '~> 2.2'
+gem 'webrick'
 gem 'sidekiq'
 
 gem 'faraday', require: false


### PR DESCRIPTION
fix two issues by specifying a fixed version in the gemfile

1. Starting from Ruby 3.0 WEBrick isn't included with Ruby by default. You should either add gem "webrick" into your Gemfile ([ref](https://github.com/yabeda-rb/yabeda-prometheus))
2. Starting from Rack version 3.0, `Rack::Handler` was removed from rack and pulled out into its own gem (rackup). ([ref](https://stackoverflow.com/a/75100160))

Below was the error when I ran the docker compose with rack 3.x and ruby 3.2.1

```
example-sidekiq-1     | #<Thread:0x0000ffff9648d690 /usr/local/bundle/gems/yabeda-prometheus-0.8.0/lib/yabeda/prometheus/exporter.rb:22 run> terminated with exception (report_on_exception is true):
example-sidekiq-1     | 2023-03-02T07:43:31.269Z pid=1 tid=1xh INFO: Running in ruby 3.2.1 (2023-02-08 revision 31819e82c8) [aarch64-linux]
example-sidekiq-1     | 2023-03-02T07:43:31.270Z pid=1 tid=1xh INFO: See LICENSE and the LGPL-3.0 for licensing details.
example-sidekiq-1     | 2023-03-02T07:43:31.270Z pid=1 tid=1xh INFO: Upgrade to Sidekiq Pro for more features and support: https://sidekiq.org/
example-sidekiq-1     | 2023-03-02T07:43:31.270Z pid=1 tid=1xh INFO: Sidekiq 7.0.6 connecting to Redis with options {:size=>5, :pool_name=>"internal", :url=>"redis://redis:6379/0"}
example-sidekiq-1     | 2023-03-02T07:43:31.273Z pid=1 tid=1xh INFO: Sidekiq 7.0.6 connecting to Redis with options {:size=>5, :pool_name=>"default", :url=>"redis://redis:6379/0"}
example-sidekiq-1     | <internal:/usr/local/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require': cannot load such file -- rack/handler (LoadError)
example-sidekiq-1     | 	from <internal:/usr/local/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
example-sidekiq-1     | 	from /usr/local/bundle/gems/yabeda-prometheus-0.8.0/lib/yabeda/prometheus/exporter.rb:24:in `block in start_metrics_server!'
```