### PR TITLE
Add query tag for http_request_total

### DIFF
--- a/lib/yabeda/http_requests.rb
+++ b/lib/yabeda/http_requests.rb
@@ -21,7 +21,7 @@ module Yabeda
       counter :request_total,
               comment: 'A counter of the total number of external HTTP \
                          requests.',
-              tags: %i[host port method]
+              tags: %i[host port method query]
       counter :response_total,
               comment: 'A counter of the total number of external HTTP \
                          responses.',

--- a/lib/yabeda/http_requests/sniffer.rb
+++ b/lib/yabeda/http_requests/sniffer.rb
@@ -10,7 +10,8 @@ module Yabeda
           {
             host: data_item.request.host,
             port: data_item.request.port,
-            method: data_item.request.method
+            method: data_item.request.method,
+            query: data_item.request.query
           }
         )
       end


### PR DESCRIPTION
I found that README.md has example of `http_request_total` with **query** tag

```
http_request_total{host="dev.to",port="443",method="GET",query="/amplifr"} 145.0
```

But actual code does not have this tag

